### PR TITLE
MAINT: update installation instructions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,7 @@ omit =
     versioneer.py
 
 [report]
+fail_under = 90
 omit =
     */tests*
     */__init__.py

--- a/README.md
+++ b/README.md
@@ -4,28 +4,23 @@ QIIME 2 plugin for PCA analysis of protein sequences, as described by Wang & Ken
 
 ## Installation
 
-Create a new conda environment and install required dependencies:
-
+Install mamba into your base environment (if not already done):
+```shell
+conda install mamba -n base -c conda-forge
 ```
-conda create -yn protein-pca \
-  -c conda-forge -c bioconda -c qiime2 -c defaults \
-  qiime2 q2cli q2templates q2-types q2-alignment q2-emperor click==7.1.2
+
+Create a new conda environment and install q2-protein-pca with its dependencies:
+```shell
+mamba create -yn protein-pca \
+  -c conda-forge -c bioconda -c https://packages.qiime2.org/qiime2/2022.4/tested -c defaults \
+  q2-protein-pca q2cli q2-emperor
 conda activate protein-pca
 ```
 
-Finally, install q2-protein-pca:
-
-```
-conda install -y \
-  -c https://packages.qiime2.org/qiime2/2021.8/tested \
-  --no-deps q2-protein-pca
-```
-
 To see actions available within the q2-protein-pca plugin:
-
-```
+```shell
 qiime dev refresh-cache
-qiime --help
+qiime protein-pca --help
 ```
 
 ## Usage

--- a/q2_protein_pca/plugin_setup.py
+++ b/q2_protein_pca/plugin_setup.py
@@ -24,7 +24,7 @@ citations = Citations.load('citations.bib', package='q2_protein_pca')
 plugin = Plugin(
     name='protein-pca',
     version=q2_protein_pca.__version__,
-    website="https://github.com/misialq/pca-protein-analysis",
+    website="https://github.com/bokulich-lab/q2-protein-pca",
     package='q2_protein_pca',
     description=(
         'This QIIME 2 plugin supports methods for PCA analysis of ranked'


### PR DESCRIPTION
This PR updates and/or adds:
- the installation instructions (use mamba and new conda channel for env creation)
- correct repo link in `plugin_setup.py`
- missing coverage failure threshold 